### PR TITLE
Add the official distribution of closure templates as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Then specify what files to compress in your config:
       all: {
         /** @required  - string including grunt glob variables*/
         src: './static/template/**/*.soy',
-        /** @required  - string including grunt glob variables*/
-        soyToJsJarPath: './closure-library/template/SoyToJsSrcCompiler.jar',
         /** @optional  - defaults to '{INPUT_DIRECTORY}/{INPUT_FILE_NAME}.js' */
         outputPathFormat: '{INPUT_DIRECTORY}/{INPUT_FILE_NAME}.js'
         /** any other parameter included on the options will be added to call */

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "node": "*"
   },
   "dependencies": {
+    "google-closure-templates": "^20150403.0.1",
     "grunt": "~0.4.1"
   },
   "keywords": [

--- a/tasks/grunt-closure-soy.js
+++ b/tasks/grunt-closure-soy.js
@@ -10,6 +10,9 @@ module.exports = function (grunt) {
 		outputPathFormat: '{INPUT_DIRECTORY}/{INPUT_FILE_NAME}.js'
 	};
 
+	var soyToJsJarPath = require.resolve('google-closure-templates');
+	soyToJsJarPath = soyToJsJarPath.replace(/\/package.json$/, '/javascript/SoyToJsSrcCompiler.jar');
+
 	grunt.registerMultiTask('closureSoys', "SOYs (Google Closure) template generator", function () {
 		var _ = grunt.util._;
 		var done = this.async();
@@ -20,7 +23,7 @@ module.exports = function (grunt) {
 		var args = [];
 
 		// path to jar is always the first parameter
-		args.push(['-jar', config.soyToJsJarPath]);
+		args.push(['-jar', soyToJsJarPath]);
 		// output format which is required
 		args.push(['--outputPathFormat', config.outputPathFormat]);
 


### PR DESCRIPTION
Closure templates has now been officially published to NPM. Include the official package as a dependency and remove the requirement/option of specifying the jar path.
